### PR TITLE
解决相机 iqoo z3 选择照片后，app闪退的问题

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,6 @@
             android:screenOrientation="fullSensor">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.dakingx.app.photopicker">
 
+    <!--miui系统调用截图模块需要这个权限-->
+    <uses-permission android:name="com.miui.mediaeditor.permission.CROP" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -13,7 +16,7 @@
         tools:ignore="HardcodedDebugMode">
         <activity
             android:name=".MainActivity"
-            android:screenOrientation="portrait">
+            android:screenOrientation="fullSensor">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -31,5 +34,4 @@
                 android:resource="@xml/file_paths" />
         </provider>
     </application>
-
 </manifest>

--- a/app/src/main/java/com/dakingx/app/photopicker/MainActivity.kt
+++ b/app/src/main/java/com/dakingx/app/photopicker/MainActivity.kt
@@ -1,9 +1,9 @@
 package com.dakingx.app.photopicker
 
 import android.net.Uri
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
 import com.dakingx.app.photopicker.config.getFileProviderAuthority
 import com.dakingx.photopicker.ext.toBitmap
 import com.dakingx.photopicker.fragment.PhotoFragment
@@ -89,26 +89,26 @@ class MainActivity : AppCompatActivity() {
 
     private fun requestPermission(vararg permission: String, successAction: () -> Unit) {
         Dexter.withContext(this)
-            .withPermissions(*permission).withListener(object :
-                MultiplePermissionsListener {
-                override fun onPermissionsChecked(report: MultiplePermissionsReport) {
-                    if (report.areAllPermissionsGranted()) {
-                        runOnUiThread {
-                            successAction()
-                        }
-                    } else {
-                        runOnUiThread {
-                            toast(R.string.main_tip_lack_permission)
+            .withPermissions(*permission).withListener(
+                object : MultiplePermissionsListener {
+                    override fun onPermissionsChecked(report: MultiplePermissionsReport) {
+                        if (report.areAllPermissionsGranted()) {
+                            runOnUiThread {
+                                successAction()
+                            }
+                        } else {
+                            runOnUiThread {
+                                toast(R.string.main_tip_lack_permission)
+                            }
                         }
                     }
-                }
 
-                override fun onPermissionRationaleShouldBeShown(
-                    list: MutableList<PermissionRequest>,
-                    token: PermissionToken
-                ) {
-                    token.continuePermissionRequest()
-                }
-            }).check()
+                    override fun onPermissionRationaleShouldBeShown(
+                        list: MutableList<PermissionRequest>,
+                        token: PermissionToken
+                    ) {
+                        token.continuePermissionRequest()
+                    }
+                }).check()
     }
 }

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -16,5 +16,4 @@
     <external-cache-path
         name="external_cache"
         path="." />
-
 </paths>

--- a/photo-picker/build.gradle
+++ b/photo-picker/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-android-extensions'
 
 apply plugin: 'com.github.dcendents.android-maven'
 
-group='com.github.dakingx'
+group = 'com.github.dakingx'
 
 android {
     compileSdkVersion compile_sdk_version

--- a/photo-picker/src/main/java/com/dakingx/photopicker/util/PhotoUtil.kt
+++ b/photo-picker/src/main/java/com/dakingx/photopicker/util/PhotoUtil.kt
@@ -17,7 +17,7 @@ suspend fun capturePhoto(fm: FragmentManager, authority: String): PhotoOpResult 
     suspendCancellableCoroutine { continuation ->
         val fragment = getPhotoFragment(fm, authority)
         fragment.capture(
-            genCropPhotoCb(fragment, continuation)
+            genCropPhotoCb(fragment, true, continuation)
         )
     }
 
@@ -28,32 +28,33 @@ suspend fun pickPhoto(fm: FragmentManager, authority: String): PhotoOpResult =
     suspendCancellableCoroutine { continuation ->
         val fragment = getPhotoFragment(fm, authority)
         fragment.pick(
-            genCropPhotoCb(fragment, continuation)
+            genCropPhotoCb(fragment, false, continuation)
         )
     }
 
 /**
  * 处理裁剪
+ * @param fromeCamera true:拍照；false:文件选图。
  */
 private fun genCropPhotoCb(
     fragment: PhotoFragment,
+    fromeCamera: Boolean,
     continuation: CancellableContinuation<PhotoOpResult>
-) =
-    object : PhotoOpCallback {
-        override fun invoke(result: PhotoOpResult) {
-            when (result) {
-                is PhotoOpResult.Success -> {
-                    // 裁剪
-                    fragment.crop(result.uri) { cropResult ->
-                        continuation.resumeSafely(cropResult)
-                    }
+) = object : PhotoOpCallback {
+    override fun invoke(result: PhotoOpResult) {
+        when (result) {
+            is PhotoOpResult.Success -> {
+                // 裁剪
+                fragment.crop(result.uri, fromeCamera) { cropResult ->
+                    continuation.resumeSafely(cropResult)
                 }
-                else -> {
-                    continuation.resumeSafely(result)
-                }
+            }
+            else -> {
+                continuation.resumeSafely(result)
             }
         }
     }
+}
 
 /**
  * 裁剪


### PR DESCRIPTION
iqoo z3在选择图片的时候，会导致闪退，原因是拍照需要flag、而从相册选择的时候不需要，所以关键是添加下面一行代码即可，其他的内容就是做了一些优化
`                if (fromeCamera) {
            putExtra("noFaceDetection", true)	                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
            putExtra("crop", "true")	                }`